### PR TITLE
Replace mounts with more secure volume syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Copy and paste the whole section below the point `services` and change the value
 docker create \
 -p <serverport>:<serverport>/udp \
 -p <serverport + 1>:<serverport + 1>/udp \
---mount type=bind,source="<re home dir>",target=/re-server-config/home \
---mount type=bind,source="<re package dir>",target=/re-server-config/package \
---mount type=bind,source="<sauerbraten dir>",target=/re-server-config/sauer \
+--mount type=volume,source="<re home dir>",target=/re-server-config/home,readonly=true \
+--mount type=volume,source="<re package dir>",target=/re-server-config/package,readonly=true \
+--mount type=volume,source="<sauerbraten dir>",target=/re-server-config/sauer,readonly=true \
 --name <name> \
 iceflower/redeclipse-server:<tag>
 ```
@@ -100,9 +100,9 @@ Create a container, with changed values and another name and start it.
 docker create \
 -p <serverport>:<serverport>/udp \
 -p <serverport + 1>:<serverport + 1>/udp \
--v /home/iceflower/redeclipse-config/devel_home:/re-server-config/home:ro \
--v /home/iceflower/redeclipse-config/package:/re-server-config/package:ro \
--v /home/iceflower/redeclipse-config/sauerbraten:/re-server-config/sauer:ro \
+--mount type=volume,source="/home/iceflower/redeclipse-config/devel_home",target=/re-server-config/home,readonly=true \
+--mount type=volume,source="/home/iceflower/redeclipse-config/package",target=/re-server-config/package,readonly=true \
+--mount type=volume,source="/home/iceflower/redeclipse-config/sauerbraten",target=/re-server-config/sauer,readonly=true \
 --name re-dev-server \
 iceflower/redeclipse-server:master
 ```

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Create a container, with changed values and another name and start it.
 docker create \
 -p <serverport>:<serverport>/udp \
 -p <serverport + 1>:<serverport + 1>/udp \
---mount type=bind,source="/home/iceflower/redeclipse-config/devel_home",target=/re-server-config/home \
---mount type=bind,source="/home/iceflower/redeclipse-config/package",target=/re-server-config/package \
---mount type=bind,source="/home/iceflower/redeclipse-config/sauerbraten",target=/re-server-config/sauer \
+-v /home/iceflower/redeclipse-config/devel_home:/re-server-config/home:ro \
+-v /home/iceflower/redeclipse-config/package:/re-server-config/package:ro \
+-v /home/iceflower/redeclipse-config/sauerbraten:/re-server-config/sauer:ro \
 --name re-dev-server \
 iceflower/redeclipse-server:master
 ```

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -8,12 +8,15 @@ services:
             - "28802:28802/udp"
         restart: unless-stopped
         volumes:
-            - type: bind
+            - type: volume
               source: /home/iceflower/redeclipse-config/devel_home
               target: /re-server-config/home
-            - type: bind
+              readonly: true
+            - type: volume
               source: /home/iceflower/redeclipse-config/package
               target: /re-server-config/package
-            - type: bind
+              readonly: true
+            - type: volume
               source: /home/iceflower/redeclipse-config/sauerbraten
               target: /re-server-config/sauer
+              readonly: true

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -8,12 +8,15 @@ services:
             - "<serverport + 1>:<serverport + 1>/udp"
         restart: unless-stopped
         volumes:
-            - type: bind
+            - type: volume
               source: <re home dir>
               target: /re-server-config/home
-            - type: bind
+              readonly: true
+            - type: volume
               source: <re package dir>
               target: /re-server-config/package
-            - type: bind
+              readonly: true
+            - type: volume
               source: <sauerbraten dir>
               target: /re-server-config/sauer
+              readonly: true


### PR DESCRIPTION
Also, make them read only to disallow write access in a proper way. Before, @IceflowRE relied on the Docker user to not have permissions to those directories. But in theory, both the outside user ID and the Docker container user ID might be the same, which then bypasses the "protection". The read-only volumes are anyway more secure (volume > mount).